### PR TITLE
chore: deprecate SDK and prepare for archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED - Kinde Elixir SDK
 
-> **⚠️ This SDK is deprecated and this repository has been archived.**
+> **⚠️ This SDK is deprecated and this repository will be archived.**
 >
 > **Effective Date:** November 17, 2025
 >
@@ -12,8 +12,8 @@ Due to low adoption and usage, we made the decision to deprecate the Kinde Elixi
 
 - **No new features** will be added to this SDK
 - **No bug fixes** will be provided
-- **No support** is available for this SDK
-- The repository is now in **read-only mode**
+- **No SDK-specific support or maintenance** will be provided
+- The repository will be set to **read-only mode**
 
 ## Migration Options
 
@@ -46,10 +46,10 @@ If you're currently using this SDK in production:
 - The SDK will continue to function as-is, but we recommend migrating to direct API integration
 - Test thoroughly in a development environment before switching in production
 
-## Need Help?
+## Need Help Migrating?
 
 - **Join our community:** [Kinde Slack Community](https://kinde.com/community/)
-- **Contact support:** [support@kinde.com](mailto:support@kinde.com)
+- **General Kinde support:** [support@kinde.com](mailto:support@kinde.com)
 - **Documentation:** [docs.kinde.com](https://docs.kinde.com/)
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 > **Support Ended:** December 31, 2025
 
-Due to low adoption and usage, we made the decision to deprecate the Kinde Elixir SDK. This allows us to focus our resources on SDKs with higher demand and better serve the broader Kinde community.
+Due to low adoption and usage, we decided to deprecate the Kinde Elixir SDK. This allows us to focus our resources on SDKs with higher demand and better serve the broader Kinde community.
 
 ## What This Means
 
@@ -22,7 +22,7 @@ Due to low adoption and usage, we made the decision to deprecate the Kinde Elixi
 The Kinde Elixir SDK was a wrapper around our API. You can integrate directly with the [Kinde API](https://kinde.com/api/docs/) using any HTTP client library in Elixir (such as `HTTPoison`, `Req`, or `Finch`).
 
 - [Kinde API Reference](https://kinde.com/api/docs/)
-- [Kinde Authentication Overview](https://docs.kinde.com/developer-tools/about/our-apis/)
+- [Using Kinde without an SDK](https://docs.kinde.com/developer-tools/about/using-kinde-without-an-sdk/)
 
 ### Option 2: Community-Maintained Alternatives
 
@@ -34,10 +34,10 @@ If your architecture allows, consider using one of our actively maintained SDKs:
 
 - [Node.js SDK](https://github.com/kinde-oss/kinde-nodejs-sdk)
 - [Python SDK](https://github.com/kinde-oss/kinde-python-sdk)
-- [Go SDK](https://github.com/kinde-oss/kinde-go-sdk)
+- [Go SDK](https://github.com/kinde-oss/kinde-go)
 - [PHP SDK](https://github.com/kinde-oss/kinde-php-sdk)
 
-[View all Kinde SDKs](https://docs.kinde.com/developer-tools/sdks/official-sdks/)
+[View all Kinde SDKs](https://docs.kinde.com/developer-tools/about/our-sdks/)
 
 ## For Existing Users
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED - Kinde Elixir SDK
 
-> **⚠️ This SDK is deprecated and this repository will be archived.**
+> **⚠️ This SDK is deprecated and this repository has been archived.**
 >
 > **Effective Date:** November 17, 2025
 >
@@ -13,7 +13,7 @@ Due to low adoption and usage, we decided to deprecate the Kinde Elixir SDK. Thi
 - **No new features** will be added to this SDK
 - **No bug fixes** will be provided
 - **No SDK-specific support or maintenance** will be provided
-- The repository will be set to **read-only mode**
+- The repository is in **read-only mode**
 
 ## Migration Options
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,63 @@
-# Kinde Elixir
+# DEPRECATED - Kinde Elixir SDK
 
-The Kinde SDK for Elixir.
+> **⚠️ This SDK is deprecated and this repository has been archived.**
+>
+> **Effective Date:** November 17, 2025
+>
+> **Support Ended:** December 31, 2025
 
-You can also use the Elixir starter kit [here](https://github.com/kinde-starter-kits/elixir-starter-kit).
+Due to low adoption and usage, we made the decision to deprecate the Kinde Elixir SDK. This allows us to focus our resources on SDKs with higher demand and better serve the broader Kinde community.
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com) [![Kinde Docs](https://img.shields.io/badge/Kinde-Docs-eee?style=flat-square)](https://kinde.com/docs/developer-tools) [![Kinde Community](https://img.shields.io/badge/Kinde-Community-eee?style=flat-square)](https://thekindecommunity.slack.com)
+## What This Means
 
-### Initial set up
+- **No new features** will be added to this SDK
+- **No bug fixes** will be provided
+- **No support** is available for this SDK
+- The repository is now in **read-only mode**
 
-1. Clone the repository to your machine:
+## Migration Options
 
-   ```bash
-   git clone https://github.com/kinde-oss/kinde-elixir-sdk.git
-   ```
+### Option 1: Use Kinde's API Directly
 
-2. Go into the project:
+The Kinde Elixir SDK was a wrapper around our API. You can integrate directly with the [Kinde API](https://kinde.com/api/docs/) using any HTTP client library in Elixir (such as `HTTPoison`, `Req`, or `Finch`).
 
-   ```bash
-   cd kinde-elixir-sdk
-   ```
+- [Kinde API Reference](https://kinde.com/api/docs/)
+- [Kinde Authentication Overview](https://docs.kinde.com/developer-tools/about/our-apis/)
 
-3. Install the dependencies:
+### Option 2: Community-Maintained Alternatives
 
-   ```bash
-   mix deps.get
-   ```
-   
-## Documentation
+If a community member creates an alternative Elixir SDK, we'll link to it here. Check our [developer community](https://kinde.com/community/) for updates.
 
-For details on integrating this SDK into your project, head over to the [Kinde docs](https://kinde.com/docs/) and see the [Elixir SDK](https://kinde.com/docs/developer-tools/elixir-sdk/) doc 👍🏼.
+### Option 3: Use Another Language SDK
 
-## Publishing
+If your architecture allows, consider using one of our actively maintained SDKs:
 
-The core team handles publishing.
-## Contributing
+- [Node.js SDK](https://github.com/kinde-oss/kinde-nodejs-sdk)
+- [Python SDK](https://github.com/kinde-oss/kinde-python-sdk)
+- [Go SDK](https://github.com/kinde-oss/kinde-go-sdk)
+- [PHP SDK](https://github.com/kinde-oss/kinde-php-sdk)
 
-Please refer to Kinde’s [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
+[View all Kinde SDKs](https://docs.kinde.com/developer-tools/sdks/official-sdks/)
+
+## For Existing Users
+
+If you're currently using this SDK in production:
+
+- The SDK will continue to function as-is, but we recommend migrating to direct API integration
+- Test thoroughly in a development environment before switching in production
+
+## Need Help?
+
+- **Join our community:** [Kinde Slack Community](https://kinde.com/community/)
+- **Contact support:** [support@kinde.com](mailto:support@kinde.com)
+- **Documentation:** [docs.kinde.com](https://docs.kinde.com/)
+
+---
+
+We appreciate everyone who used and contributed to this SDK. Thank you for being part of the Kinde community.
+
+**— The Kinde Team**
 
 ## License
 
-By contributing to Kinde, you agree that your contributions will be licensed under its MIT License.
+MIT License. See [LICENSE](LICENSE) for details.

--- a/mix.exs
+++ b/mix.exs
@@ -4,13 +4,13 @@ defmodule KindeSDK.Mixfile do
   def project do
     [
       app: :kinde_sdk,
-      version: "1.2.0",
+      version: "1.2.1",
       elixir: "~> 1.10",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       package: package(),
       aliases: aliases(),
-      description: "Provides endpoints to manage your Kinde Businesses",
+      description: "DEPRECATED - Kinde Elixir SDK. See GitHub repo for migration options.",
       deps: deps()
     ]
   end
@@ -54,7 +54,10 @@ defmodule KindeSDK.Mixfile do
       name: "kinde_sdk",
       files: ~w(config lib test .formatter.exs .gitignore LICENSE* mix.exs README*),
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/kinde-oss/kinde-elixir-sdk"}
+      links: %{
+        "GitHub" => "https://github.com/kinde-oss/kinde-elixir-sdk",
+        "Kinde API Reference" => "https://kinde.com/api/docs/"
+      }
     ]
   end
 


### PR DESCRIPTION
# Explain your changes

Deprecate the Kinde Elixir SDK and prepare the repository for archiving.

**README.md:**
- Replace all existing content with a deprecation notice, migration options (direct API integration, community alternatives, other language SDKs), guidance for existing users, and support contact info

**mix.exs:**
- Bump version from 1.2.0 to 1.2.1 for a final Hex.pm publish
- Update package description to indicate deprecation
- Add Kinde API Reference link to package metadata

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._